### PR TITLE
fix issue #32 mongodb ODM missing support for `.` notation

### DIFF
--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -202,9 +202,16 @@ class Document extends Source
             $properties = $this->getClassProperties($resource);
 
             foreach ($columns as $column) {
-                if (isset($properties[$column->getId()])) {
-                    $row->setField($column->getId(), $properties[$column->getId()]);
+                $hierarchy = explode('.', $column->getId());
+                $length = count($hierarchy);
+                $node = $resource;
+                for ($i = 0; $i < $length; $i++) {
+                    if (isset($node)) {
+                        $node = $this->getClassProperties($node);
+                        $node = $node[strtolower($hierarchy[$i])];
+                    }
                 }
+                $row->setField($column->getId(), $node);
             }
 
             //call overridden prepareRow or associated closure
@@ -233,7 +240,7 @@ class Document extends Source
 
         foreach ($props as $property) {
             $property->setAccessible(true);
-            $result[$property->getName()] = $property->getValue($obj);
+            $result[strtolower($property->getName())] = $property->getValue($obj);
         }
 
         return $result;
@@ -249,6 +256,7 @@ class Document extends Source
 
             if (isset($mapping['fieldName'])) {
                 $values['field'] = $mapping['fieldName'];
+                $values['id'] = $mapping['fieldName'];
             }
 
             if (isset($mapping['id']) && $mapping['id'] == 'id') {
@@ -280,6 +288,15 @@ class Document extends Source
                 case 'date':
                 case 'timestamp':
                     $values['type'] = 'date';
+                    break;
+                case 'collection':
+                    $values['type'] = 'array';
+                    break;
+                case 'one':
+                    $values['type'] = 'array';
+                    break;
+                case 'many':
+                    $values['type'] = 'array';
                     break;
                 default:
                     $values['type'] = 'text';


### PR DESCRIPTION
Actually '.' notation works well when executing the query. The subsequent filling record into row caused the data missing.
So I added the logic to handle '.' notation at ```APY\DataGridBundle\Grid\Source\Document::execute() line 205```
```php
foreach ($columns as $column) {
      $hierarchy = explode('.', $column->getId());
      $length = count($hierarchy);
      $node = $resource;
      for ($i = 0; $i < $length; $i++) {
            if (isset($node)) {
                 $node = $this->getClassProperties($node);
                 $node = $node[strtolower($hierarchy[$i])];
            }
      }
      $row->setField($column->getId(), $node);
}
```
In case of annotation field differs in uppercase/lowercase from actual class property , I had them unified in lowercase:
```php
$result[strtolower($property->getName())] = $property->getValue($obj);
```
To access referenced document's property, the referenced document's id is a must whatever actual property is eventually retrieved.
At class annotation:
```php
@GRID\Source(columns = "id, owner.id, owner.username")
```
At property annotation:
```php
@GRID\Column(field = "owner.id", visible = false)
@GRID\Column(field = "owner.username")
```