### PR TITLE
Case insensitive LIKE filters

### DIFF
--- a/Grid/Column/Column.php
+++ b/Grid/Column/Column.php
@@ -37,10 +37,10 @@ abstract class Column
     const OPERATOR_NLIKE  = 'nlike';
     const OPERATOR_RLIKE  = 'rlike';
     const OPERATOR_LLIKE  = 'llike';
-    const OPERATOR_ILIKE   = 'ilike'; //case insensitive
-    const OPERATOR_NILIKE  = 'nilike';
-    const OPERATOR_RILIKE  = 'rilike';
-    const OPERATOR_LILIKE  = 'lilike';
+    const OPERATOR_SLIKE   = 'slike'; //simple/strict LIKE
+    const OPERATOR_NSLIKE  = 'nslike';
+    const OPERATOR_RSLIKE  = 'rslike';
+    const OPERATOR_LSLIKE  = 'lslike';
     
     const OPERATOR_ISNULL  = 'isNull';
     const OPERATOR_ISNOTNULL  = 'isNotNull';
@@ -150,10 +150,10 @@ abstract class Column
             self::OPERATOR_NLIKE,
             self::OPERATOR_RLIKE,
             self::OPERATOR_LLIKE,
-            self::OPERATOR_ILIKE,
-            self::OPERATOR_NILIKE,
-            self::OPERATOR_RILIKE,
-            self::OPERATOR_LILIKE,
+            self::OPERATOR_SLIKE,
+            self::OPERATOR_NSLIKE,
+            self::OPERATOR_RSLIKE,
+            self::OPERATOR_LSLIKE,
             self::OPERATOR_ISNULL,
             self::OPERATOR_ISNOTNULL,
         )));
@@ -622,16 +622,16 @@ abstract class Column
                     case self::OPERATOR_LIKE:
                     case self::OPERATOR_RLIKE:
                     case self::OPERATOR_LLIKE:
-                    case self::OPERATOR_ILIKE:
-                    case self::OPERATOR_RILIKE:
-                    case self::OPERATOR_LILIKE:
+                    case self::OPERATOR_SLIKE:
+                    case self::OPERATOR_RSLIKE:
+                    case self::OPERATOR_LSLIKE:
                         if ($this->getSelectMulti()) {
                             $this->setDataJunction(self::DATA_DISJUNCTION);
                         }
                     case self::OPERATOR_EQ:
                     case self::OPERATOR_NEQ:
                     case self::OPERATOR_NLIKE:
-                    case self::OPERATOR_NILIKE:
+                    case self::OPERATOR_NSLIKE:
                         foreach ((array) $this->data['from'] as $value) {
                             $filters[] = new Filter($this->data['operator'], $value);
                         }

--- a/Grid/Column/Column.php
+++ b/Grid/Column/Column.php
@@ -37,6 +37,11 @@ abstract class Column
     const OPERATOR_NLIKE  = 'nlike';
     const OPERATOR_RLIKE  = 'rlike';
     const OPERATOR_LLIKE  = 'llike';
+    const OPERATOR_ILIKE   = 'ilike'; //case insensitive
+    const OPERATOR_NILIKE  = 'nilike';
+    const OPERATOR_RILIKE  = 'rilike';
+    const OPERATOR_LILIKE  = 'lilike';
+    
     const OPERATOR_ISNULL  = 'isNull';
     const OPERATOR_ISNOTNULL  = 'isNotNull';
 
@@ -145,6 +150,10 @@ abstract class Column
             self::OPERATOR_NLIKE,
             self::OPERATOR_RLIKE,
             self::OPERATOR_LLIKE,
+            self::OPERATOR_ILIKE,
+            self::OPERATOR_NILIKE,
+            self::OPERATOR_RILIKE,
+            self::OPERATOR_LILIKE,
             self::OPERATOR_ISNULL,
             self::OPERATOR_ISNOTNULL,
         )));
@@ -613,12 +622,16 @@ abstract class Column
                     case self::OPERATOR_LIKE:
                     case self::OPERATOR_RLIKE:
                     case self::OPERATOR_LLIKE:
+                    case self::OPERATOR_ILIKE:
+                    case self::OPERATOR_RILIKE:
+                    case self::OPERATOR_LILIKE:
                         if ($this->getSelectMulti()) {
                             $this->setDataJunction(self::DATA_DISJUNCTION);
                         }
                     case self::OPERATOR_EQ:
                     case self::OPERATOR_NEQ:
                     case self::OPERATOR_NLIKE:
+                    case self::OPERATOR_NILIKE:
                         foreach ((array) $this->data['from'] as $value) {
                             $filters[] = new Filter($this->data['operator'], $value);
                         }

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -100,10 +100,10 @@ class Document extends Source
             case Column::OPERATOR_NLIKE:
             case Column::OPERATOR_RLIKE:
             case Column::OPERATOR_LLIKE:
-            case Column::OPERATOR_ILIKE:
-            case Column::OPERATOR_NILIKE:
-            case Column::OPERATOR_RILIKE:
-            case Column::OPERATOR_LILIKE:
+            case Column::OPERATOR_SLIKE:
+            case Column::OPERATOR_NSLIKE:
+            case Column::OPERATOR_RSLIKE:
+            case Column::OPERATOR_LSLIKE:
             case Column::OPERATOR_NEQ:
                 return 'equals';
             case Column::OPERATOR_ISNULL:
@@ -122,21 +122,21 @@ class Document extends Source
             case Column::OPERATOR_NEQ:
                 return new \MongoRegex('/^(?!'.$value.'$).*$/i');
             case Column::OPERATOR_LIKE:
-                return new \MongoRegex('/'.$value.'/');
-            case Column::OPERATOR_NLIKE:
-                return new \MongoRegex('/^((?!'.$value.').)*$/');
-            case Column::OPERATOR_RLIKE:
-                return new \MongoRegex('/^'.$value.'/');
-            case Column::OPERATOR_LLIKE:
-                return new \MongoRegex('/'.$value.'$/');
-            case Column::OPERATOR_ILIKE:
                 return new \MongoRegex('/'.$value.'/i');
-            case Column::OPERATOR_NILIKE:
+            case Column::OPERATOR_NLIKE:
                 return new \MongoRegex('/^((?!'.$value.').)*$/i');
-            case Column::OPERATOR_RILIKE:
+            case Column::OPERATOR_RLIKE:
                 return new \MongoRegex('/^'.$value.'/i');
-            case Column::OPERATOR_LILIKE:
+            case Column::OPERATOR_LLIKE:
                 return new \MongoRegex('/'.$value.'$/i');
+            case Column::OPERATOR_SLIKE:
+                return new \MongoRegex('/'.$value.'/');
+            case Column::OPERATOR_SLIKE:
+                return new \MongoRegex('/^((?!'.$value.').)*$/');
+            case Column::OPERATOR_RSLIKE:
+                return new \MongoRegex('/^'.$value.'/');
+            case Column::OPERATOR_LSLIKE:
+                return new \MongoRegex('/'.$value.'$/');
             case Column::OPERATOR_ISNULL:
                 return false;
             case Column::OPERATOR_ISNOTNULL:
@@ -332,7 +332,7 @@ class Document extends Source
                 // For negative operators, show all values
                 if ($selectFrom === 'query') {
                     foreach ($column->getFilters('document') as $filter) {
-                        if (in_array($filter->getOperator(), array(Column::OPERATOR_NEQ, Column::OPERATOR_NLIKE,Column::OPERATOR_NILIKE))) {
+                        if (in_array($filter->getOperator(), array(Column::OPERATOR_NEQ, Column::OPERATOR_NLIKE,Column::OPERATOR_NSLIKE))) {
                             $selectFrom = 'source';
                             break;
                         }

--- a/Grid/Source/Document.php
+++ b/Grid/Source/Document.php
@@ -100,6 +100,10 @@ class Document extends Source
             case Column::OPERATOR_NLIKE:
             case Column::OPERATOR_RLIKE:
             case Column::OPERATOR_LLIKE:
+            case Column::OPERATOR_ILIKE:
+            case Column::OPERATOR_NILIKE:
+            case Column::OPERATOR_RILIKE:
+            case Column::OPERATOR_LILIKE:
             case Column::OPERATOR_NEQ:
                 return 'equals';
             case Column::OPERATOR_ISNULL:
@@ -118,12 +122,20 @@ class Document extends Source
             case Column::OPERATOR_NEQ:
                 return new \MongoRegex('/^(?!'.$value.'$).*$/i');
             case Column::OPERATOR_LIKE:
-                return new \MongoRegex('/'.$value.'/i');
+                return new \MongoRegex('/'.$value.'/');
             case Column::OPERATOR_NLIKE:
-                return new \MongoRegex('/^((?!'.$value.').)*$/i');
+                return new \MongoRegex('/^((?!'.$value.').)*$/');
             case Column::OPERATOR_RLIKE:
-                return new \MongoRegex('/^'.$value.'/i');
+                return new \MongoRegex('/^'.$value.'/');
             case Column::OPERATOR_LLIKE:
+                return new \MongoRegex('/'.$value.'$/');
+            case Column::OPERATOR_ILIKE:
+                return new \MongoRegex('/'.$value.'/i');
+            case Column::OPERATOR_NILIKE:
+                return new \MongoRegex('/^((?!'.$value.').)*$/i');
+            case Column::OPERATOR_RILIKE:
+                return new \MongoRegex('/^'.$value.'/i');
+            case Column::OPERATOR_LILIKE:
                 return new \MongoRegex('/'.$value.'$/i');
             case Column::OPERATOR_ISNULL:
                 return false;
@@ -320,7 +332,7 @@ class Document extends Source
                 // For negative operators, show all values
                 if ($selectFrom === 'query') {
                     foreach ($column->getFilters('document') as $filter) {
-                        if (in_array($filter->getOperator(), array(Column::OPERATOR_NEQ, Column::OPERATOR_NLIKE))) {
+                        if (in_array($filter->getOperator(), array(Column::OPERATOR_NEQ, Column::OPERATOR_NLIKE,Column::OPERATOR_NILIKE))) {
                             $selectFrom = 'source';
                             break;
                         }

--- a/Grid/Source/Entity.php
+++ b/Grid/Source/Entity.php
@@ -254,10 +254,10 @@ class Entity extends Source
             case Column::OPERATOR_LLIKE:
             case Column::OPERATOR_RLIKE:
             case Column::OPERATOR_NLIKE:
-            case Column::OPERATOR_ILIKE:
-            case Column::OPERATOR_LILIKE:
-            case Column::OPERATOR_RILIKE:
-            case Column::OPERATOR_NILIKE:
+            case Column::OPERATOR_SLIKE:
+            case Column::OPERATOR_LSLIKE:
+            case Column::OPERATOR_RSLIKE:
+            case Column::OPERATOR_NSLIKE:
                              return 'like';
             default:
                 return $operator;
@@ -270,14 +270,14 @@ class Entity extends Source
             //case Column::OPERATOR_REGEXP:
             case Column::OPERATOR_LIKE:
             case Column::OPERATOR_NLIKE:
-            case Column::OPERATOR_ILIKE:
-            case Column::OPERATOR_NILIKE:
+            case Column::OPERATOR_SLIKE:
+            case Column::OPERATOR_NSLIKE:
                 return "%$value%";
             case Column::OPERATOR_LLIKE:
-            case Column::OPERATOR_LLIKE:
+            case Column::OPERATOR_LSLIKE:
                 return "%$value";
             case Column::OPERATOR_RLIKE:
-            case Column::OPERATOR_RLIKE:
+            case Column::OPERATOR_RSLIKE:
                 return "$value%";
             default:
                 return $value;
@@ -373,14 +373,14 @@ class Entity extends Source
 
                     $fieldName = $this->getFieldName($columnForFilter, false);
                     $bindIndexPlaceholder = "?$bindIndex";
-                    if( in_array($filter->getOperator(), array(Column::OPERATOR_ILIKE,Column::OPERATOR_RILIKE,Column::OPERATOR_LILIKE,Column::OPERATOR_NILIKE,))){
+                    if( in_array($filter->getOperator(), array(Column::OPERATOR_LIKE,Column::OPERATOR_RLIKE,Column::OPERATOR_LLIKE,Column::OPERATOR_NLIKE,))){
                         $fieldName = "LOWER($fieldName)";
                         $bindIndexPlaceholder = "LOWER($bindIndexPlaceholder)";
                     }
                     
                     $q = $this->query->expr()->$operator($fieldName, $bindIndexPlaceholder);
 
-                    if ($filter->getOperator() == Column::OPERATOR_NLIKE || $filter->getOperator() == Column::OPERATOR_NILIKE) {
+                    if ($filter->getOperator() == Column::OPERATOR_NLIKE || $filter->getOperator() == Column::OPERATOR_NSLIKE) {
                         $q = $this->query->expr()->not($q);
                     }
 
@@ -610,7 +610,7 @@ class Entity extends Source
                 // For negative operators, show all values
                 if ($selectFrom === 'query') {
                     foreach ($column->getFilters('entity') as $filter) {
-                        if (in_array($filter->getOperator(), array(Column::OPERATOR_NEQ, Column::OPERATOR_NLIKE,Column::OPERATOR_NILIKE))) {
+                        if (in_array($filter->getOperator(), array(Column::OPERATOR_NEQ, Column::OPERATOR_NLIKE,Column::OPERATOR_NSLIKE))) {
                             $selectFrom = 'source';
                             break;
                         }

--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -277,15 +277,27 @@ abstract class Source implements DriverInterface
                                     $value = '/^(?!'.preg_quote($value, '/').'$).*$/i';
                                     break;
                                 case Column\Column::OPERATOR_LIKE:
-                                    $value = '/'.preg_quote($value, '/').'/i';
+                                    $value = '/'.preg_quote($value, '/').'/';
                                     break;
                                 case Column\Column::OPERATOR_NLIKE:
-                                    $value = '/^((?!'.preg_quote($value, '/').').)*$/i';
+                                    $value = '/^((?!'.preg_quote($value, '/').').)*$/';
                                     break;
                                 case Column\Column::OPERATOR_LLIKE:
-                                    $value = '/'.preg_quote($value, '/').'$/i';
+                                    $value = '/'.preg_quote($value, '/').'$/';
                                     break;
                                 case Column\Column::OPERATOR_RLIKE:
+                                    $value = '/^'.preg_quote($value, '/').'/';
+                                    break;
+                                case Column\Column::OPERATOR_ILIKE:
+                                    $value = '/'.preg_quote($value, '/').'/i';
+                                    break;
+                                case Column\Column::OPERATOR_NILIKE:
+                                    $value = '/^((?!'.preg_quote($value, '/').').)*$/i';
+                                    break;
+                                case Column\Column::OPERATOR_LILIKE:
+                                    $value = '/'.preg_quote($value, '/').'$/i';
+                                    break;
+                                case Column\Column::OPERATOR_RILIKE:
                                     $value = '/^'.preg_quote($value, '/').'/i';
                                     break;
                             }
@@ -307,6 +319,10 @@ abstract class Source implements DriverInterface
                             case Column\Column::OPERATOR_NLIKE:
                             case Column\Column::OPERATOR_LLIKE:
                             case Column\Column::OPERATOR_RLIKE:
+                            case Column\Column::OPERATOR_ILIKE:
+                            case Column\Column::OPERATOR_NILIKE:
+                            case Column\Column::OPERATOR_LILIKE:
+                            case Column\Column::OPERATOR_RILIKE:
                                 $fieldValue = $this->prepareStringForLikeCompare($fieldValue, $column->getType());
 
                                 $found = preg_match($value, $fieldValue);
@@ -455,7 +471,7 @@ abstract class Source implements DriverInterface
                 // For negative operators, show all values
                 if ($selectFrom === 'query') {
                     foreach ($column->getFilters('vector') as $filter) {
-                        if (in_array($filter->getOperator(), array(Column\Column::OPERATOR_NEQ, Column\Column::OPERATOR_NLIKE))) {
+                        if (in_array($filter->getOperator(), array(Column\Column::OPERATOR_NEQ, Column\Column::OPERATOR_NLIKE,Column\Column::OPERATOR_NILIKE))) {
                             $selectFrom = 'source';
                             break;
                         }

--- a/Grid/Source/Source.php
+++ b/Grid/Source/Source.php
@@ -277,28 +277,28 @@ abstract class Source implements DriverInterface
                                     $value = '/^(?!'.preg_quote($value, '/').'$).*$/i';
                                     break;
                                 case Column\Column::OPERATOR_LIKE:
-                                    $value = '/'.preg_quote($value, '/').'/';
-                                    break;
-                                case Column\Column::OPERATOR_NLIKE:
-                                    $value = '/^((?!'.preg_quote($value, '/').').)*$/';
-                                    break;
-                                case Column\Column::OPERATOR_LLIKE:
-                                    $value = '/'.preg_quote($value, '/').'$/';
-                                    break;
-                                case Column\Column::OPERATOR_RLIKE:
-                                    $value = '/^'.preg_quote($value, '/').'/';
-                                    break;
-                                case Column\Column::OPERATOR_ILIKE:
                                     $value = '/'.preg_quote($value, '/').'/i';
                                     break;
-                                case Column\Column::OPERATOR_NILIKE:
+                                case Column\Column::OPERATOR_NLIKE:
                                     $value = '/^((?!'.preg_quote($value, '/').').)*$/i';
                                     break;
-                                case Column\Column::OPERATOR_LILIKE:
+                                case Column\Column::OPERATOR_LLIKE:
                                     $value = '/'.preg_quote($value, '/').'$/i';
                                     break;
-                                case Column\Column::OPERATOR_RILIKE:
+                                case Column\Column::OPERATOR_RLIKE:
                                     $value = '/^'.preg_quote($value, '/').'/i';
+                                    break;
+                                case Column\Column::OPERATOR_SLIKE:
+                                    $value = '/'.preg_quote($value, '/').'/';
+                                    break;
+                                case Column\Column::OPERATOR_NSLIKE:
+                                    $value = '/^((?!'.preg_quote($value, '/').').)*$/';
+                                    break;
+                                case Column\Column::OPERATOR_LSLIKE:
+                                    $value = '/'.preg_quote($value, '/').'$/';
+                                    break;
+                                case Column\Column::OPERATOR_RSLIKE:
+                                    $value = '/^'.preg_quote($value, '/').'/';
                                     break;
                             }
                         }
@@ -319,10 +319,10 @@ abstract class Source implements DriverInterface
                             case Column\Column::OPERATOR_NLIKE:
                             case Column\Column::OPERATOR_LLIKE:
                             case Column\Column::OPERATOR_RLIKE:
-                            case Column\Column::OPERATOR_ILIKE:
-                            case Column\Column::OPERATOR_NILIKE:
-                            case Column\Column::OPERATOR_LILIKE:
-                            case Column\Column::OPERATOR_RILIKE:
+                            case Column\Column::OPERATOR_SLIKE:
+                            case Column\Column::OPERATOR_NSLIKE:
+                            case Column\Column::OPERATOR_LSLIKE:
+                            case Column\Column::OPERATOR_RSLIKE:
                                 $fieldValue = $this->prepareStringForLikeCompare($fieldValue, $column->getType());
 
                                 $found = preg_match($value, $fieldValue);
@@ -471,7 +471,7 @@ abstract class Source implements DriverInterface
                 // For negative operators, show all values
                 if ($selectFrom === 'query') {
                     foreach ($column->getFilters('vector') as $filter) {
-                        if (in_array($filter->getOperator(), array(Column\Column::OPERATOR_NEQ, Column\Column::OPERATOR_NLIKE,Column\Column::OPERATOR_NILIKE))) {
+                        if (in_array($filter->getOperator(), array(Column\Column::OPERATOR_NEQ, Column\Column::OPERATOR_NLIKE,Column\Column::OPERATOR_NSLIKE))) {
                             $selectFrom = 'source';
                             break;
                         }

--- a/Resources/doc/columns_configuration/types/join_column.md
+++ b/Resources/doc/columns_configuration/types/join_column.md
@@ -63,10 +63,14 @@ Everything.
 |lte|Lower than or equal to|
 |gt|Greater than|
 |gte|Greater than or equal to|
-|like|Contains|
-|nlike|Not contain|
-|rlike|Starts with|
-|llike|Ends with|
+|like|Contains (case insensitive)|
+|nlike|Not contain (case insensitive)|
+|rlike|Starts with (case insensitive)|
+|llike|Ends with (case insensitive)|
+|slike|Contains|
+|nslike|Not contain|
+|rslike|Starts with|
+|lslike|Ends with|
 |btw|Between exclusive|
 |btwe|Between inclusive|
 |isNull|Is not defined|

--- a/Resources/doc/columns_configuration/types/text_column.md
+++ b/Resources/doc/columns_configuration/types/text_column.md
@@ -27,10 +27,14 @@ Everything.
 |lte|Lower than or equal to|
 |gt|Greater than|
 |gte|Greater than or equal to|
-|like|Contains|
-|nlike|Not contain|
-|rlike|Starts with|
-|llike|Ends with|
+|like|Contains (case insensitive)|
+|nlike|Not contain (case insensitive)|
+|rlike|Starts with (case insensitive)|
+|llike|Ends with (case insensitive)|
+|slike|Contains|
+|nslike|Not contain|
+|rslike|Starts with|
+|lslike|Ends with|
 |btw|Between exclusive|
 |btwe|Between inclusive|
 |isNull|Is not defined|

--- a/Resources/doc/grid_configuration/set_default_filters.md
+++ b/Resources/doc/grid_configuration/set_default_filters.md
@@ -42,14 +42,22 @@ $grid->setDefaultFilters($filters);
 |lte|Lower than or equal to|
 |gt|Greater than|
 |gte|Greater than or equal to|
-|like|Contains|
-|nlike|Not contain|
-|rlike|Starts with|
-|llike|Ends with|
+|like|Contains (case insensitive)|
+|nlike|Not contain (case insensitive)|
+|rlike|Starts with (case insensitive)|
+|llike|Ends with (case insensitive)|
+|slike|Contains|
+|nslike|Not contain|
+|rslike|Starts with|
+|lslike|Ends with|
 |btw|Between exclusive|
 |btwe|Between inclusive|
 |isNull|Is not defined|
 |isNotNull|Is defined|
+
+**Note**: LIKE filter is case insensitive by default, the resulting SQL query will look like `LOWER(column) LIKE LOWER(:criteria)`.
+
+SLIKE filter does not mean "case sensitive like", it is strict/simple LIKE so case sensitivity will depend of your RDBSM (collation, etc.).
 
 ## Example
 

--- a/Resources/doc/grid_configuration/set_permanent_filters.md
+++ b/Resources/doc/grid_configuration/set_permanent_filters.md
@@ -42,10 +42,14 @@ $grid->setPermanentFilters($filters);
 |lte|Lower than or equal to|
 |gt|Greater than|
 |gte|Greater than or equal to|
-|like|Contains|
-|nlike|Not contain|
-|rlike|Starts with|
-|llike|Ends with|
+|like|Contains (case insensitive)|
+|nlike|Not contain (case insensitive)|
+|rlike|Starts with (case insensitive)|
+|llike|Ends with (case insensitive)|
+|slike|Contains|
+|nslike|Not contain|
+|rslike|Starts with|
+|lslike|Ends with|
 |btw|Between exclusive|
 |btwe|Between inclusive|
 |isNull|Is not defined|

--- a/Resources/translations/messages.en.xliff
+++ b/Resources/translations/messages.en.xliff
@@ -67,6 +67,7 @@
                 <target>%count% Result, |%count% Results, </target>
             </trans-unit>
 
+
     <!-- with symbols -->
             <!--trans-unit id="26">
                 <source>eqs</source>
@@ -120,6 +121,23 @@
                 <source>btwes</source>
                 <target>&lt;=x&lt;<=/target>
             </trans-unit-->
+            
+            <trans-unit id="39">
+                <source>ilike</source>
+                <target>Contains (case insensitive)</target>
+            </trans-unit>
+            <trans-unit id="40">
+                <source>nilike</source>
+                <target>Not contains (case insensitive)</target>
+            </trans-unit>
+            <trans-unit id="41">
+                <source>rliike</source>
+                <target>Starts with (case insensitive)</target>
+            </trans-unit>
+            <trans-unit id="42">
+                <source>lilike</source>
+                <target>Ends with (case insensitive)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/messages.en.xliff
+++ b/Resources/translations/messages.en.xliff
@@ -123,20 +123,20 @@
             </trans-unit-->
             
             <trans-unit id="39">
-                <source>ilike</source>
-                <target>Contains (case insensitive)</target>
+                <source>slike</source>
+                <target>Contains</target>
             </trans-unit>
             <trans-unit id="40">
-                <source>nilike</source>
-                <target>Not contains (case insensitive)</target>
+                <source>nslike</source>
+                <target>Not contains</target>
             </trans-unit>
             <trans-unit id="41">
-                <source>rliike</source>
-                <target>Starts with (case insensitive)</target>
+                <source>rslike</source>
+                <target>Starts with</target>
             </trans-unit>
             <trans-unit id="42">
-                <source>lilike</source>
-                <target>Ends with (case insensitive)</target>
+                <source>lslike</source>
+                <target>Ends with</target>
             </trans-unit>
         </body>
     </file>

--- a/Resources/translations/messages.fr.xliff
+++ b/Resources/translations/messages.fr.xliff
@@ -125,7 +125,23 @@
             <trans-unit id="31">
                 <source>Order by</source>
                 <target>Trier par</target>
-            </trans-unit>            
+            </trans-unit>
+            <trans-unit id="32">
+                <source>ilike</source>
+                <target>Contient (insensible à la casse)</target>
+            </trans-unit>
+            <trans-unit id="33">
+                <source>nilike</source>
+                <target>Ne contient pas (insensible à la casse)</target>
+            </trans-unit>
+            <trans-unit id="34">
+                <source>rliike</source>
+                <target>Commence par (insensible à la casse)</target>
+            </trans-unit>
+            <trans-unit id="35">
+                <source>lilike</source>
+                <target>Finit par (insensible à la casse)</target>
+            </trans-unit>
         </body>
     </file>
 </xliff>

--- a/Resources/translations/messages.fr.xliff
+++ b/Resources/translations/messages.fr.xliff
@@ -127,20 +127,20 @@
                 <target>Trier par</target>
             </trans-unit>
             <trans-unit id="32">
-                <source>ilike</source>
-                <target>Contient (insensible à la casse)</target>
+                <source>slike</source>
+                <target>Contient</target>
             </trans-unit>
             <trans-unit id="33">
-                <source>nilike</source>
-                <target>Ne contient pas (insensible à la casse)</target>
+                <source>nslike</source>
+                <target>Ne contient pas</target>
             </trans-unit>
             <trans-unit id="34">
-                <source>rliike</source>
-                <target>Commence par (insensible à la casse)</target>
+                <source>rslike</source>
+                <target>Commence par</target>
             </trans-unit>
             <trans-unit id="35">
-                <source>lilike</source>
-                <target>Finit par (insensible à la casse)</target>
+                <source>lslike</source>
+                <target>Finit par</target>
             </trans-unit>
         </body>
     </file>


### PR DESCRIPTION
Add ILIKE, NILIKE, LILIKE, RILIKE operators (case insensitive search)
add en and fr translation for ilike,rilike nilike,lilike
Reference #679

It's just an implementation suggestion, the other option would be to add a $caseSensitive boolean field in Filter to avoid duplication of operators;
