### PR TITLE
Fix wrong default junction for eq and select multi

### DIFF
--- a/Grid/Column/Column.php
+++ b/Grid/Column/Column.php
@@ -625,10 +625,10 @@ abstract class Column
                     case self::OPERATOR_SLIKE:
                     case self::OPERATOR_RSLIKE:
                     case self::OPERATOR_LSLIKE:
+                    case self::OPERATOR_EQ:
                         if ($this->getSelectMulti()) {
                             $this->setDataJunction(self::DATA_DISJUNCTION);
                         }
-                    case self::OPERATOR_EQ:
                     case self::OPERATOR_NEQ:
                     case self::OPERATOR_NLIKE:
                     case self::OPERATOR_NSLIKE:


### PR DESCRIPTION
No difference between eq and like operator for select multi feature. Why the default junction is not the same? I think that you have always no result with a junction on the same field.

Related to #224.